### PR TITLE
Node.connect :"gatekeeper@127.0.0.1"

### DIFF
--- a/otp/src/tweet_aggregator/README.md
+++ b/otp/src/tweet_aggregator/README.md
@@ -51,7 +51,11 @@ iex(client1@127.0.0.1)1> Node.connect :"aggregator@127.0.0.1"
 true
 NodeMonitor: aggregator@127.0.0.1 joined
 
-iex(client1@127.0.0.1)2> TweetAggregator.Search.Client.poll ["elixir"]
+iex(client1@127.0.0.1)2> Node.connect :"gatekeeper@127.0.0.1"
+true
+NodeMonitor: gatekeeper@127.0.0.1 joined
+
+iex(client1@127.0.0.1)3> TweetAggregator.Search.Client.poll ["elixir"]
 New results
 Client: Got 1 result(s)
 ```


### PR DESCRIPTION
The Gatekeeper node needs to be connected too, otherwise `:global.registered_names` only reports `[:aggregator]` and not `[:gatekeeper, :aggregator]`.
